### PR TITLE
fix(django_atomic_requests): atomic requests can now be enabled

### DIFF
--- a/src/_example/django/django_demo/app/forest/address.py
+++ b/src/_example/django/django_demo/app/forest/address.py
@@ -17,7 +17,7 @@ from forestadmin.datasource_toolkit.interfaces.records import RecordsDataAlias
 
 
 async def high_delivery_address_segment(context: CollectionCustomizationContext):
-    rows = await context.datasource.get_collection("Order").aggregate(
+    rows = await context.datasource.get_collection("app_order").aggregate(
         context.caller,
         Filter({}),
         Aggregation(

--- a/src/_example/django/django_demo/app/management/commands/populate-db.py
+++ b/src/_example/django/django_demo/app/management/commands/populate-db.py
@@ -6,9 +6,11 @@ from app.flask_models import FlaskAddress, FlaskCart, FlaskCustomer, FlaskCustom
 from app.models import Address, Cart, Customer, CustomerAddress, Order
 from django.contrib.auth.models import Group, User
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from faker import Faker
 
 fake = Faker(["it_IT", "en_US", "ja_JP", "fr_FR"])
+fr_fake = Faker(["fr_FR"])
 
 
 class Command(BaseCommand):
@@ -33,6 +35,7 @@ class Command(BaseCommand):
             action="store_true",
         )
 
+    @transaction.atomic()
     def handle(self, *args, **options):
         numbers = {
             "groups": 4,
@@ -126,7 +129,7 @@ def create_addresses(customers, nb_addresses=500):
             number=fake.building_number(),
             city=fake.city(),
             country=fake.country(),
-            zip_code=fake.postcode(),
+            zip_code=fr_fake.postcode(),
         )
         addresses.append(a)
     Address.objects.bulk_create(addresses)

--- a/src/_example/django/django_demo/django_demo/settings.py
+++ b/src/_example/django/django_demo/django_demo/settings.py
@@ -103,6 +103,7 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+        "ATOMIC_REQUESTS": True,
     },
     "other": {
         "ENGINE": "django.db.backends.sqlite3",

--- a/src/datasource_toolkit/forestadmin/datasource_toolkit/interfaces/query/condition_tree/factory.py
+++ b/src/datasource_toolkit/forestadmin/datasource_toolkit/interfaces/query/condition_tree/factory.py
@@ -53,7 +53,7 @@ class ConditionTreeFactory:
     @classmethod
     def intersect(cls, trees: List[ConditionTree]) -> ConditionTree:
         result = ConditionTreeFactory._group(Aggregator.AND, trees)
-        if isinstance(result, ConditionTreeBranch) and not len(result.conditions) == 0:
+        if isinstance(result, ConditionTreeBranch) and len(result.conditions) == 0:
             return None
         return result
 

--- a/src/datasource_toolkit/forestadmin/datasource_toolkit/interfaces/query/condition_tree/factory.py
+++ b/src/datasource_toolkit/forestadmin/datasource_toolkit/interfaces/query/condition_tree/factory.py
@@ -53,8 +53,8 @@ class ConditionTreeFactory:
     @classmethod
     def intersect(cls, trees: List[ConditionTree]) -> ConditionTree:
         result = ConditionTreeFactory._group(Aggregator.AND, trees)
-        if isinstance(result, ConditionTreeBranch) and not result.conditions:
-            raise ConditionTreeFactoryException("Empty intersect")
+        if isinstance(result, ConditionTreeBranch) and not len(result.conditions) == 0:
+            return None
         return result
 
     @classmethod

--- a/src/datasource_toolkit/tests/interfaces/query/condition_tree/test_factory.py
+++ b/src/datasource_toolkit/tests/interfaces/query/condition_tree/test_factory.py
@@ -113,9 +113,7 @@ def test_intersect(group_mock: mock.Mock):
     ]
     tree = ConditionTreeBranch(Aggregator.AND, [])
     group_mock.return_value = tree
-    with pytest.raises(ConditionTreeFactoryException) as e:
-        ConditionTreeFactory.intersect(trees)
-    assert str(e.value) == "🌳🌳🌳Empty intersect"
+    assert ConditionTreeFactory.intersect(trees) is None
 
     tree = ConditionTreeBranch(Aggregator.AND, trees)
     group_mock.return_value = tree

--- a/src/django_agent/forestadmin/django_agent/views/actions.py
+++ b/src/django_agent/forestadmin/django_agent/views/actions.py
@@ -1,14 +1,17 @@
+from asgiref.sync import async_to_sync
 from django.http import HttpRequest
 from forestadmin.django_agent.apps import DjangoAgentApp
 from forestadmin.django_agent.utils.converter import convert_request, convert_response
 
 
+@async_to_sync
 async def hook(request: HttpRequest, **kwargs):
     resource = (await DjangoAgentApp.get_agent().get_resources())["actions"]
     response = await resource.dispatch(convert_request(request, kwargs), "hook")
     return convert_response(response)
 
 
+@async_to_sync
 async def execute(request: HttpRequest, **kwargs):
     resource = (await DjangoAgentApp.get_agent().get_resources())["actions"]
     response = await resource.dispatch(convert_request(request, kwargs), "execute")

--- a/src/django_agent/forestadmin/django_agent/views/authentication.py
+++ b/src/django_agent/forestadmin/django_agent/views/authentication.py
@@ -1,8 +1,10 @@
+from django.db import transaction
 from django.http import HttpRequest
 from forestadmin.django_agent.apps import DjangoAgentApp
 from forestadmin.django_agent.utils.converter import convert_request, convert_response
 
 
+@transaction.non_atomic_requests
 async def authentication(request: HttpRequest):
     resource = (await DjangoAgentApp.get_agent().get_resources())["authentication"]
     response = await resource.dispatch(convert_request(request), "authenticate")
@@ -13,6 +15,7 @@ async def authentication(request: HttpRequest):
 authentication.csrf_exempt = True
 
 
+@transaction.non_atomic_requests
 async def callback(request: HttpRequest):
     resource = (await DjangoAgentApp.get_agent().get_resources())["authentication"]
     response = await resource.dispatch(convert_request(request), "callback")

--- a/src/django_agent/forestadmin/django_agent/views/charts.py
+++ b/src/django_agent/forestadmin/django_agent/views/charts.py
@@ -1,14 +1,17 @@
+from django.db import transaction
 from django.http import HttpRequest
 from forestadmin.django_agent.apps import DjangoAgentApp
 from forestadmin.django_agent.utils.converter import convert_request, convert_response
 
 
+@transaction.non_atomic_requests
 async def chart_collection(request: HttpRequest, **kwargs):
     resource = (await DjangoAgentApp.get_agent().get_resources())["collection_charts"]
     response = await resource.dispatch(convert_request(request, kwargs), "add")
     return convert_response(response)
 
 
+@transaction.non_atomic_requests
 async def chart_datasource(request: HttpRequest, **kwargs):
     resource = (await DjangoAgentApp.get_agent().get_resources())["datasource_charts"]
     response = await resource.dispatch(convert_request(request, kwargs), "add")

--- a/src/django_agent/forestadmin/django_agent/views/crud.py
+++ b/src/django_agent/forestadmin/django_agent/views/crud.py
@@ -1,9 +1,12 @@
+from asgiref.sync import async_to_sync
+from django.db import transaction
 from django.http import HttpRequest
 from forestadmin.django_agent.apps import DjangoAgentApp
 from forestadmin.django_agent.utils.converter import convert_request, convert_response
 from forestadmin.django_agent.utils.dispatcher import get_dispatcher_method
 
 
+@async_to_sync
 async def detail(request: HttpRequest, **kwargs):
     resource = (await DjangoAgentApp.get_agent().get_resources())["crud"]
     action = get_dispatcher_method(request.method, True)
@@ -11,18 +14,21 @@ async def detail(request: HttpRequest, **kwargs):
     return convert_response(response)
 
 
+@transaction.non_atomic_requests
 async def count(request: HttpRequest, **kwargs):
     resource = (await DjangoAgentApp.get_agent().get_resources())["crud"]
     response = await resource.dispatch(convert_request(request, kwargs), "count")
     return convert_response(response)
 
 
+@transaction.non_atomic_requests
 async def csv(request: HttpRequest, **kwargs):
     resource = (await DjangoAgentApp.get_agent().get_resources())["crud"]
     response = await resource.dispatch(convert_request(request, kwargs), "csv")
     return convert_response(response)
 
 
+@async_to_sync
 async def list_(request: HttpRequest, **kwargs):
     resource = (await DjangoAgentApp.get_agent().get_resources())["crud"]
     action = get_dispatcher_method(request.method, False)

--- a/src/django_agent/forestadmin/django_agent/views/crud_related.py
+++ b/src/django_agent/forestadmin/django_agent/views/crud_related.py
@@ -1,21 +1,26 @@
+from asgiref.sync import async_to_sync
+from django.db import transaction
 from django.http import HttpRequest
 from forestadmin.django_agent.apps import DjangoAgentApp
 from forestadmin.django_agent.utils.converter import convert_request, convert_response
 from forestadmin.django_agent.utils.dispatcher import get_dispatcher_method
 
 
+@transaction.non_atomic_requests
 async def count(request: HttpRequest, **kwargs):
     resource = (await DjangoAgentApp.get_agent().get_resources())["crud_related"]
     response = await resource.dispatch(convert_request(request, kwargs), "count")
     return convert_response(response)
 
 
+@transaction.non_atomic_requests
 async def csv(request: HttpRequest, **kwargs):
     resource = (await DjangoAgentApp.get_agent().get_resources())["crud_related"]
     response = await resource.dispatch(convert_request(request, kwargs), "csv")
     return convert_response(response)
 
 
+@async_to_sync
 async def list_(request: HttpRequest, **kwargs):
     resource = (await DjangoAgentApp.get_agent().get_resources())["crud_related"]
     action = get_dispatcher_method(request.method, False)

--- a/src/django_agent/forestadmin/django_agent/views/index.py
+++ b/src/django_agent/forestadmin/django_agent/views/index.py
@@ -1,11 +1,14 @@
+from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 from forestadmin.django_agent.apps import DjangoAgentApp
 
 
+@transaction.non_atomic_requests
 async def index(request: HttpRequest):
     return HttpResponse(status=200)
 
 
+@transaction.non_atomic_requests
 async def scope_cache_invalidation(request: HttpRequest):
     DjangoAgentApp.get_agent()._permission_service.invalidate_cache("forest.scopes")
     return HttpResponse(status=204)

--- a/src/django_agent/forestadmin/django_agent/views/stats.py
+++ b/src/django_agent/forestadmin/django_agent/views/stats.py
@@ -1,8 +1,10 @@
+from django.db import transaction
 from django.http import HttpRequest
 from forestadmin.django_agent.apps import DjangoAgentApp
 from forestadmin.django_agent.utils.converter import convert_request, convert_response
 
 
+@transaction.non_atomic_requests
 async def stats(request: HttpRequest, **kwargs):
     resource = (await DjangoAgentApp.get_agent().get_resources())["stats"]
     response = await resource.dispatch(convert_request(request, kwargs))


### PR DESCRIPTION
`ATOMIC_REQUESTS` setting permit to decorate each http request in a transaction. This setting is incompatible with async views, that the agent use.

`async_to_sync` permit to run view in a thread where transaction are allowed, whereas for readonly view we prefer to not use transaction (`transaction.non_atomic_requests`)