### PR TITLE
fix(native_driver): usage is now the same in django and sqlalchemy

### DIFF
--- a/src/_example/django/django_demo/app/forest/address.py
+++ b/src/_example/django/django_demo/app/forest/address.py
@@ -8,21 +8,16 @@ from forestadmin.datasource_toolkit.interfaces.query.condition_tree.nodes.base i
 from forestadmin.datasource_toolkit.interfaces.query.condition_tree.nodes.leaf import ConditionTreeLeaf
 from forestadmin.datasource_toolkit.interfaces.query.filter.unpaginated import Filter
 from forestadmin.datasource_toolkit.interfaces.records import RecordsDataAlias
-from sqlalchemy import text
-from sqlalchemy.orm.session import Session
 
 
 # segments
 def segment_addr_fr(table_name: str):
     def segment_addr_fr(context: CollectionCustomizationContext) -> ConditionTree:
         with context.collection.get_native_driver() as driver:
-            if isinstance(driver, Session):  # if is sqlalchemy driver
-                ret = driver.execute(text(f"select country from {table_name} where country like 'france'"))
-            else:
-                ret = driver.execute(f"select country from {table_name} where country like 'france'")
-            countries = [r[0] for r in ret]
+            ret = driver.execute(f"select distinct country from {table_name} where country like '%france%'")
+            rows = [*ret]
 
-            return ConditionTreeLeaf(field="country", operator="in", value=countries)
+        return ConditionTreeLeaf(field="country", operator="in", value=[r[0] for r in rows])
 
     return segment_addr_fr
 

--- a/src/datasource_sqlalchemy/tests/test_sqlalchemy_collections.py
+++ b/src/datasource_sqlalchemy/tests/test_sqlalchemy_collections.py
@@ -304,12 +304,19 @@ class TestSqlAlchemyCollectionWithModels(TestCase):
         assert [*filter(lambda item: item["group"]["customer_id"] == 10, results)][0]["value"] == 3408.5
 
     def test_get_native_driver_should_return_connection(self):
-        Session_ = self.datasource.get_collection("order").get_native_driver()
-        with Session_() as connection:
+        with self.datasource.get_collection("order").get_native_driver() as connection:
             self.assertIsInstance(connection, Session)
             self.assertEqual(str(connection.bind.url), f"sqlite:///{models.test_db_path}")
 
             rows = connection.execute(text('select id,amount from "order"  where id =  3')).all()
+        self.assertEqual(rows, [(3, 5285)])
+
+    def test_get_native_driver_should_work_without_declaring_request_as_text(self):
+        with self.datasource.get_collection("order").get_native_driver() as connection:
+            self.assertIsInstance(connection, Session)
+            self.assertEqual(str(connection.bind.url), f"sqlite:///{models.test_db_path}")
+
+            rows = connection.execute('select id,amount from "order"  where id =  3').all()
         self.assertEqual(rows, [(3, 5285)])
 
 


### PR DESCRIPTION
The corresponding doc PR: https://github.com/ForestAdmin/developer-guide/pull/237